### PR TITLE
fix: trigger auto-release on dependency update

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -8,6 +8,16 @@
     }
   ],
   "plugins": ["@semantic-release/commit-analyzer", "@semantic-release/release-notes-generator", "@semantic-release/github"],
+  "analyzeCommits": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          {"type": "chore", "release": "patch"}
+        ]
+      }
+    ]
+  ],
   "prepare": [
     [
       "@semantic-release/exec",


### PR DESCRIPTION
### Auto-release for new GRPC methods

When trying to use the [`ListEventsAsync` method](https://zitadel.com/docs/apis/proto/admin#listevents) provided by Zitadel's administration API, I found that the current NuGet package `5.0.16` does not include the necessary commands. The repository, however, included all necessary dependencies and the method exists. While a new and updated NuGet package exists as a build artifact in one GitHub action, `semantic-release` regards all commits as irrelevant and hence no package is published to [nuget.org](https://nuget.org).

Investigating the release configuration, I was able to see that the automatic releases were not triggered since some time last year, whereas the node SDK repository continuously released new versions.

I updated the release configuration so that contributions made through the renovate bot trigger a patch release resulting in a NuGet package.

I validated the release of a new version with a dry-run of `semantic-release`, which lead to the following output:

```ps1
...
  semantic-release:commit-analyzer The rule { type: 'chore', release: 'patch' } match commit with release type 'patch' +0ms
[14:30:59] [semantic-release] [@semantic-release/commit-analyzer] » i  The release type for the commit is patch
[14:30:59] [semantic-release] [@semantic-release/commit-analyzer] » i  Analysis of 20 commits complete: patch release
[14:30:59] [semantic-release] » √  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[14:30:59] [semantic-release] » i  The next release version is 5.0.17
[14:30:59] [semantic-release] » i  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
  semantic-release:release-notes-generator version: '5.0.17' +0ms
  semantic-release:release-notes-generator host: undefined +1ms
  semantic-release:release-notes-generator owner: 'lfcyja' +0ms
  semantic-release:release-notes-generator repository: 'zitadel-net' +0ms
  semantic-release:release-notes-generator previousTag: 'v5.0.16' +0ms
  semantic-release:release-notes-generator currentTag: 'v5.0.17' +0ms
  semantic-release:release-notes-generator host: 'https://github.com' +0ms
  semantic-release:release-notes-generator linkReferences: undefined +1ms
  semantic-release:release-notes-generator issue: 'issues' +0ms
  semantic-release:release-notes-generator commit: 'commit' +0ms
[14:30:59] [semantic-release] » √  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[14:30:59] [semantic-release] » ‼  Skip step "prepare" of plugin "@semantic-release/exec" in dry-run mode
[14:30:59] [semantic-release] » ‼  Skip v5.0.17 tag creation in dry-run mode
[14:30:59] [semantic-release] » ‼  Skip step "publish" of plugin "@semantic-release/exec" in dry-run mode
[14:30:59] [semantic-release] » ‼  Skip step "publish" of plugin "@semantic-release/github" in dry-run mode
[14:30:59] [semantic-release] » ‼  Skip step "success" of plugin "@semantic-release/github" in dry-run mode
[14:30:59] [semantic-release] » √  Published release 5.0.17 on default channel
[14:30:59] [semantic-release] » i  Release note for version 5.0.17:
## 5.0.17 (https://github.com/lfcyja/zitadel-net/compare/v5.0.16...v5.0.17) (2023-02-07)
```