### PR TITLE
Fixes the IsInRole() extension method

### DIFF
--- a/src/Zitadel/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Zitadel/Extensions/ClaimsPrincipalExtensions.cs
@@ -15,7 +15,14 @@ public static class ClaimsPrincipalExtensions
     /// <param name="roles">List of roles. One of them must be present on the principal.</param>
     /// <returns>True if any role is on the principal. False otherwise.</returns>
     public static bool IsInRole(this ClaimsPrincipal principal, params string[] roles) =>
-        roles.Select(principal.IsInRole).Any();
+        roles.Any(principal.IsInRole);
+
+    public static bool IsInRole2(this ClaimsPrincipal principal, params string[] roles)
+    {
+        var mappedValues = roles.Select(principal.IsInRole);
+        bool checkIfThereAreElements = mappedValues.Any();
+        return checkIfThereAreElements;
+    }
 
     /// <summary>
     /// Checks a principal if it inherits a specific role in context of an organization.
@@ -35,5 +42,5 @@ public static class ClaimsPrincipalExtensions
     /// <param name="roles">List of roles. One of them must be present on the principal.</param>
     /// <returns>True if any role is on the principal. False otherwise.</returns>
     public static bool IsInRole(this ClaimsPrincipal principal, string organizationId, params string[] roles)
-        => roles.Select(role => IsInRole(principal, organizationId, role)).Any();
+        => roles.Any(role => IsInRole(principal, organizationId, role));
 }

--- a/src/Zitadel/Extensions/ClaimsPrincipalExtensions.cs
+++ b/src/Zitadel/Extensions/ClaimsPrincipalExtensions.cs
@@ -17,13 +17,6 @@ public static class ClaimsPrincipalExtensions
     public static bool IsInRole(this ClaimsPrincipal principal, params string[] roles) =>
         roles.Any(principal.IsInRole);
 
-    public static bool IsInRole2(this ClaimsPrincipal principal, params string[] roles)
-    {
-        var mappedValues = roles.Select(principal.IsInRole);
-        bool checkIfThereAreElements = mappedValues.Any();
-        return checkIfThereAreElements;
-    }
-
     /// <summary>
     /// Checks a principal if it inherits a specific role in context of an organization.
     /// </summary>

--- a/tests/Zitadel.Test/Extensions/ClaimsPrincipalExtensionsTest.cs
+++ b/tests/Zitadel.Test/Extensions/ClaimsPrincipalExtensionsTest.cs
@@ -1,0 +1,59 @@
+using System.Security.Claims;
+using Moq;
+using Xunit;
+using Zitadel.Extensions;
+
+namespace Zitadel.Test.Extensions;
+
+public class ClaimsPrincipalExtensionsTest
+{
+    private Mock<ClaimsPrincipal> claimsPrincipal;
+
+    public ClaimsPrincipalExtensionsTest()
+    {
+        claimsPrincipal = new();
+        claimsPrincipal.Setup(c => c.IsInRole("negative")).Returns(false);
+        claimsPrincipal.Setup(c => c.IsInRole("positive")).Returns(true);
+    }
+
+    [Fact]
+    public void IsInSingleRole()
+    {
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "positive" });
+
+        Assert.True(actual);
+        claimsPrincipal.Verify(c => c.IsInRole("positive"), Times.Once);
+        claimsPrincipal.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void IsInOneOfTheGivenRoles()
+    {
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "negative", "positive" });
+
+        Assert.True(actual);
+        claimsPrincipal.Verify(c => c.IsInRole("positive"), Times.Once);
+        claimsPrincipal.Verify(c => c.IsInRole("negative"), Times.Once);
+        claimsPrincipal.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void IsNotInRole()
+    {
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "negative" });
+
+        Assert.False(actual);
+        claimsPrincipal.Verify(c => c.IsInRole("negative"), Times.Once);
+        claimsPrincipal.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void IsNotInNoneOfTheGivenRoles()
+    {
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "negative", "negative", "negative" });
+
+        Assert.False(actual);
+        claimsPrincipal.Verify(c => c.IsInRole("negative"), Times.Exactly(3));
+        claimsPrincipal.VerifyNoOtherCalls();
+    }
+}

--- a/tests/Zitadel.Test/Extensions/ClaimsPrincipalExtensionsTest.cs
+++ b/tests/Zitadel.Test/Extensions/ClaimsPrincipalExtensionsTest.cs
@@ -56,4 +56,13 @@ public class ClaimsPrincipalExtensionsTest
         claimsPrincipal.Verify(c => c.IsInRole("negative"), Times.Exactly(3));
         claimsPrincipal.VerifyNoOtherCalls();
     }
+
+    [Fact]
+    public void IsFalseForNoGivenRoles()
+    {
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, Array.Empty<string>() );
+
+        Assert.False(actual);
+        claimsPrincipal.VerifyNoOtherCalls();
+    }
 }


### PR DESCRIPTION
Before this PR, the IsInRole() extension method would return `true` as long as at least one role was provided. It returns `true`, no matter whether the user in question is a member of the respective role or not. It will return true, even if the user isn't a member of any role at all.

The cause is the use of Select() in combination with Any(). Select() maps a value of an Iterable from one form to another by invoking an Action. Any() (invoked without any further arguments) returns `true` whenever there is one or more element in an Iterable.

Select() was invoked for every role to map a given role to a boolean value that indicates whether the user is a member of this role or not. It does this by invoking `principal.IsInRole(role)`. The resulting collection is a list of boolean values that may be either `true` or `false`. The list may also contain only `false` values (⚠️). The final Any() only checks if there are elements in the list. Therefore, it will return `true` in all cases, except if no role was provided to begin with.

Taken apart, this is what's happening, explained as code:

```cs
// given a valid principal that has no roles assigned
// given an array roles with at least one role
public static bool IsInRole(this ClaimsPrincipal principal, params string[] roles) {
        var mappedValues = roles.Select(principal.IsInRole); // mappedValues = [ false ]
        bool isNotEmpty = mappedValues.Any(); // isNotEmpty = true
        return isNotEmpty; // return true ⚠️
}
```

Instead of Select(), the method Where() should have been used. Furthermore, Any() itself does except an Action. `someEnumerable.Where(somePredicate).Any()` is the same as calling `someEnumarble.Any(somePredicate)`. This commit changes the code accordingly and provides a unit test for the method in question.

I believe that this PR should be considered as a security bug, since relying on the malfunctioning IsInRole extension method could have allowed users with insufficient permission to perform actions or access data that they shouldn't be able to. [Publishing a respective security advisory](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory) should be considered, so that users of this library are alerted properly about the potential privilege escalation issue in their code.