### PR TITLE
fix: deprecated package `Microsoft.AspNetCore.Authentication`

### DIFF
--- a/src/Zitadel/Zitadel.csproj
+++ b/src/Zitadel/Zitadel.csproj
@@ -24,7 +24,6 @@
         <PackageReference Include="Grpc.Net.Common" Version="2.60.0"/>
         <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0"/>
         <PackageReference Include="jose-jwt" Version="4.1.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
This pull request removes the depreacated Authentication package. The package isn't used anywhere in the project, so it shouldn't be an issue to remove it.

- fix https://github.com/smartive/zitadel-net/issues/923