### PR TITLE
Changes needed for complete sign out and working redirect

### DIFF
--- a/examples/Zitadel.AspNet.AuthN/Pages/Authenticated.cshtml.cs
+++ b/examples/Zitadel.AspNet.AuthN/Pages/Authenticated.cshtml.cs
@@ -8,9 +8,12 @@ namespace Zitadel.AspNet.AuthN.Pages;
 [Authorize]
 public class Authenticated : PageModel
 {
-    public async Task<IActionResult> OnPostAsync()
+    public async Task OnPostAsync()
     {
-        await HttpContext.SignOutAsync();
-        return RedirectToPage("/Index");
+        await HttpContext.SignOutAsync("Identity.External"); // Options: signs you out of ZITADEL entirely, without this you may not be reprompted for your password.
+        await HttpContext.SignOutAsync(
+            ZitadelDefaults.AuthenticationScheme,
+            new AuthenticationProperties { RedirectUri = "http://localhost:8080/loggedout" }
+        );
     }
 }

--- a/examples/Zitadel.AspNet.AuthN/Pages/LoggedOut.cshtml
+++ b/examples/Zitadel.AspNet.AuthN/Pages/LoggedOut.cshtml
@@ -1,0 +1,13 @@
+﻿@page
+@model LoggedOutModel
+
+<html lang="en">
+<head>
+    <title>Logged out</title>
+</head>
+<body>
+<div>
+    <p>You are now logged out.</P>
+</div>
+</body>
+</html>

--- a/examples/Zitadel.AspNet.AuthN/Pages/LoggedOut.cshtml.cs
+++ b/examples/Zitadel.AspNet.AuthN/Pages/LoggedOut.cshtml.cs
@@ -1,0 +1,7 @@
+﻿using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Zitadel.AspNet.AuthN.Pages;
+
+public class LoggedOutModel : PageModel { }

--- a/examples/Zitadel.AspNet.AuthN/Program.cs
+++ b/examples/Zitadel.AspNet.AuthN/Program.cs
@@ -14,6 +14,7 @@ builder.Services
             o.Authority = "https://zitadel-libraries-l8boqa.zitadel.cloud/";
             o.ClientId = "170088295403946241@library";
             o.SignInScheme = IdentityConstants.ExternalScheme;
+            o.SaveTokens = true;
         })
     .AddExternalCookie()
     .Configure(


### PR DESCRIPTION
Hi,

I was testing Zitadel in an MVC application and was struggling that signing out was leaving me signed into Zitadel overall (I did not have to re-provide a password to reauthenticate).   It took me a while to figure out how to get it work with the RedirectUrl which requires `o.SaveTokens = true`

Regrettably, the solution does not build for me when I do a straight git clone and the readme doesn't have instructions on how to make it build, so I have not verified this compiles after my lift, shift, and strip drown.
