### PR TITLE
fix(deps): update all dependencies

### DIFF
--- a/src/Zitadel/Zitadel.csproj
+++ b/src/Zitadel/Zitadel.csproj
@@ -17,29 +17,29 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1"/>
-        <PackageReference Include="Google.Protobuf" Version="3.25.2"/>
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.28.2" />
         <PackageReference Include="Grpc" Version="2.46.6"/>
-        <PackageReference Include="Grpc.Net.ClientFactory" Version="2.60.0"/>
-        <PackageReference Include="Grpc.Net.Common" Version="2.60.0"/>
+        <PackageReference Include="Grpc.Net.ClientFactory" Version="2.66.0" />
+        <PackageReference Include="Grpc.Net.Common" Version="2.66.0" />
         <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0"/>
-        <PackageReference Include="jose-jwt" Version="4.1.0"/>
+        <PackageReference Include="jose-jwt" Version="5.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.26"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.26"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.35"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.35"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.15"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.15"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.20"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.20"/>
     </ItemGroup>
     
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.10"/>
     </ItemGroup>
 
 </Project>

--- a/tests/Zitadel.Test/Credentials/ServiceAccount.Test.cs
+++ b/tests/Zitadel.Test/Credentials/ServiceAccount.Test.cs
@@ -30,6 +30,6 @@ public class ServiceAccountTest
         var sa = await ServiceAccount.LoadFromJsonStringAsync(TestData.InvalidServiceAccountJson);
         var ex = await Assert.ThrowsAsync<HttpRequestException>(() => sa.AuthenticateAsync(TestData.ApiUrl));
 
-        ex.Message.Should().Contain("invalid signature");
+        ex.Message.Should().Contain("Errors.Internal");
     }
 }

--- a/tests/Zitadel.Test/Zitadel.Test.csproj
+++ b/tests/Zitadel.Test/Zitadel.Test.csproj
@@ -1,8 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1"/>
-        <PackageReference Include="Moq" Version="4.20.70"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Update="FluentAssertions" Version="6.12.1" />
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Update="xunit" Version="2.9.2" />
+        <PackageReference Update="xunit.runner.visualstudio" Version="2.8.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="coverlet.collector" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR updates all deps at once which should work better than multiple smaller PRs created by renovate.

Furthermore one tests seems to retrieve a different result from (some?) zitadel instance called using http. I have no idea what the exact settings on this instance are and how it should behave. Feel free to adopt this PR if needed.