### PR TITLE
chore(api): Allow custom ITokenProvider implementation to support header modification

### DIFF
--- a/src/Zitadel/Api/ITokenProvider.cs
+++ b/src/Zitadel/Api/ITokenProvider.cs
@@ -34,5 +34,10 @@ public interface ITokenProvider
             options);
     }
 
-    internal DelegatingHandler CreateHandler();
+    /// <summary>
+    /// Creates the delegating handler for the token provider.
+    /// Made public to allow custom ITokenProvider implementations outside Zitadel.Net.
+    /// </summary>
+    public DelegatingHandler CreateHandler();
 }
+


### PR DESCRIPTION
Currently, the `ITokenProvider` interface is public, but its required method `CreateHandler()` is internal, which prevents consumers from creating their own implementations outside of the Zitadel.Net assembly. 

I need to create a custom provider so I can modify the underlying HTTP client, specifically to adjust header parameters for authentication or other scenarios.

Please consider making CreateHandler() public or providing an alternative extensibility mechanism so developers can implement custom token providers and modify client behavior as needed.