### PR TITLE
feat: add application and action v2 service client to clients helper

### DIFF
--- a/src/Zitadel/Api/Clients.cs
+++ b/src/Zitadel/Api/Clients.cs
@@ -2,6 +2,7 @@
 using Grpc.Net.Client;
 
 using Zitadel.Admin.V1;
+using Zitadel.Application.V2;
 using Zitadel.Auth.V1;
 using Zitadel.Authentication;
 using Zitadel.Management.V1;
@@ -27,6 +28,14 @@ public static class Clients
     /// <returns>The <see cref="Admin.V1.AdminService.AdminServiceClient"/>.</returns>
     public static AdminService.AdminServiceClient AdminService(Options options) =>
         GetClient<AdminService.AdminServiceClient>(options);
+
+    /// <summary>
+    /// Create a service client for the application service.
+    /// </summary>
+    /// <param name="options">Options for the client like authorization method.</param>
+    /// <returns>The <see cref="ApplicationService.ApplicationServiceClient"/>.</returns>
+    public static ApplicationService.ApplicationServiceClient ApplicationService(Options options) =>
+        GetClient<ApplicationService.ApplicationServiceClient>(options);
 
     /// <summary>
     /// Create a service client for the auth service.

--- a/src/Zitadel/Api/Clients.cs
+++ b/src/Zitadel/Api/Clients.cs
@@ -1,6 +1,7 @@
 ﻿using Grpc.Core;
 using Grpc.Net.Client;
 
+using Zitadel.Action.V2;
 using Zitadel.Admin.V1;
 using Zitadel.Application.V2;
 using Zitadel.Auth.V1;
@@ -21,6 +22,14 @@ namespace Zitadel.Api;
 /// </summary>
 public static class Clients
 {
+    /// <summary>
+    /// Create a service client for the action service.
+    /// </summary>
+    /// <param name="options">Options for the client like authorization method.</param>
+    /// <returns>The <see cref="ActionService.ActionServiceClient"/>.</returns>
+    public static ActionService.ActionServiceClient ActionService(Options options) =>
+        GetClient<ActionService.ActionServiceClient>(options);
+
     /// <summary>
     /// Create a service client for the admin service.
     /// </summary>


### PR DESCRIPTION
The `Clients` helper class to instantiate the API service clients currently does not contain the method to create an instance of the new V2 `ApplicationService.ApplicationServiceClient` and `ActionService.ActionServiceClient`.
With this change a user can write `Clients.ApplicationService(...)` or `Clients.ActionService(...)` to instantiate the v2 application and action client.

EDIT: The test case `ServiceAccountTest.Should_Throw_With_Meaningful_Error` failed for me locally. I saw that also the [renovate PRs](https://github.com/smartive/zitadel-net/actions) failed for the same reason and also when running the tests locally on the main branch.

<img width="617" height="140" alt="image" src="https://github.com/user-attachments/assets/2f72fb1d-d18f-4122-b57e-7a75898fc6d8" />