### PR TITLE
test: migrate mocks from Moq to NSubstitute

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,7 +53,7 @@
             <_Parameter1>$(MSBuildProjectName).Test</_Parameter1>
         </AssemblyAttribute>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-            <!--So that internals are visible to the Moq library-->
+            <!--So that internals are visible to dynamic proxy-based test doubles-->
             <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>

--- a/tests/Zitadel.Test/Extensions/ClaimsPrincipalExtensionsTest.cs
+++ b/tests/Zitadel.Test/Extensions/ClaimsPrincipalExtensionsTest.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
 
-using Moq;
+using NSubstitute;
 
 using Xunit;
 
@@ -10,63 +10,63 @@ namespace Zitadel.Test.Extensions;
 
 public class ClaimsPrincipalExtensionsTest
 {
-    private readonly Mock<ClaimsPrincipal> claimsPrincipal;
+    private readonly ClaimsPrincipal claimsPrincipal;
 
     public ClaimsPrincipalExtensionsTest()
     {
-        claimsPrincipal = new();
-        claimsPrincipal.Setup(c => c.IsInRole("negative")).Returns(false);
-        claimsPrincipal.Setup(c => c.IsInRole("positive")).Returns(true);
+        claimsPrincipal = Substitute.For<ClaimsPrincipal>();
+        claimsPrincipal.IsInRole("negative").Returns(false);
+        claimsPrincipal.IsInRole("positive").Returns(true);
     }
 
     [Fact]
     public void IsInSingleRole()
     {
-        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "positive" });
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal, new[] { "positive" });
 
         Assert.True(actual);
-        claimsPrincipal.Verify(c => c.IsInRole("positive"), Times.Once);
-        claimsPrincipal.VerifyNoOtherCalls();
+        claimsPrincipal.Received(1).IsInRole("positive");
+        Assert.Single(claimsPrincipal.ReceivedCalls());
     }
 
     [Fact]
     public void IsInOneOfTheGivenRoles()
     {
-        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "negative", "positive" });
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal, new[] { "negative", "positive" });
 
         Assert.True(actual);
-        claimsPrincipal.Verify(c => c.IsInRole("positive"), Times.Once);
-        claimsPrincipal.Verify(c => c.IsInRole("negative"), Times.Once);
-        claimsPrincipal.VerifyNoOtherCalls();
+        claimsPrincipal.Received(1).IsInRole("positive");
+        claimsPrincipal.Received(1).IsInRole("negative");
+        Assert.Equal(2, claimsPrincipal.ReceivedCalls().Count());
     }
 
     [Fact]
     public void IsNotInRole()
     {
-        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "negative" });
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal, new[] { "negative" });
 
         Assert.False(actual);
-        claimsPrincipal.Verify(c => c.IsInRole("negative"), Times.Once);
-        claimsPrincipal.VerifyNoOtherCalls();
+        claimsPrincipal.Received(1).IsInRole("negative");
+        Assert.Single(claimsPrincipal.ReceivedCalls());
     }
 
     [Fact]
     public void IsNotInNoneOfTheGivenRoles()
     {
         bool actual =
-            ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, new[] { "negative", "negative", "negative" });
+            ClaimsPrincipalExtensions.IsInRole(claimsPrincipal, new[] { "negative", "negative", "negative" });
 
         Assert.False(actual);
-        claimsPrincipal.Verify(c => c.IsInRole("negative"), Times.Exactly(3));
-        claimsPrincipal.VerifyNoOtherCalls();
+        claimsPrincipal.Received(3).IsInRole("negative");
+        Assert.Equal(3, claimsPrincipal.ReceivedCalls().Count());
     }
 
     [Fact]
     public void IsFalseForNoGivenRoles()
     {
-        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal.Object, Array.Empty<string>());
+        bool actual = ClaimsPrincipalExtensions.IsInRole(claimsPrincipal, Array.Empty<string>());
 
         Assert.False(actual);
-        claimsPrincipal.VerifyNoOtherCalls();
+        Assert.Empty(claimsPrincipal.ReceivedCalls());
     }
 }

--- a/tests/Zitadel.Test/Zitadel.Test.csproj
+++ b/tests/Zitadel.Test/Zitadel.Test.csproj
@@ -2,7 +2,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Update="FluentAssertions" Version="8.9.0" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Update="xunit" Version="2.9.3" />


### PR DESCRIPTION
Replace Moq usage in unit tests to avoid SponsorLink-related friction while keeping the same verification behavior.