### PR TITLE
test: replace FluentAssertions with AwesomeAssertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="AwesomeAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Zitadel.Test/Api/ServiceAccountTokenProvider.Test.cs
+++ b/tests/Zitadel.Test/Api/ServiceAccountTokenProvider.Test.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 
 using Grpc.Core;
 

--- a/tests/Zitadel.Test/Api/StaticTokenProvider.Test.cs
+++ b/tests/Zitadel.Test/Api/StaticTokenProvider.Test.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 
 using Grpc.Core;
 

--- a/tests/Zitadel.Test/Authentication/ZitadelAuthenticationHandler.Test.cs
+++ b/tests/Zitadel.Test/Authentication/ZitadelAuthenticationHandler.Test.cs
@@ -2,7 +2,7 @@
 using System.Net.Http.Json;
 using System.Security.Claims;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/tests/Zitadel.Test/Authentication/ZitadelFakeAuthenticationHandler.Test.cs
+++ b/tests/Zitadel.Test/Authentication/ZitadelFakeAuthenticationHandler.Test.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Xunit;
 

--- a/tests/Zitadel.Test/Authentication/ZitadelProjectRolesClaimAction.Test.cs
+++ b/tests/Zitadel.Test/Authentication/ZitadelProjectRolesClaimAction.Test.cs
@@ -1,7 +1,7 @@
 ﻿using System.Security.Claims;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
 

--- a/tests/Zitadel.Test/Credentials/Application.Test.cs
+++ b/tests/Zitadel.Test/Credentials/Application.Test.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 
 using Xunit;
 

--- a/tests/Zitadel.Test/Credentials/AuthOptions.Test.cs
+++ b/tests/Zitadel.Test/Credentials/AuthOptions.Test.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 
 using Xunit;
 

--- a/tests/Zitadel.Test/Credentials/ServiceAccount.Test.cs
+++ b/tests/Zitadel.Test/Credentials/ServiceAccount.Test.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using AwesomeAssertions;
 
 using Xunit;
 

--- a/tests/Zitadel.Test/Zitadel.Test.csproj
+++ b/tests/Zitadel.Test/Zitadel.Test.csproj
@@ -3,7 +3,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="NSubstitute" />
-        <PackageReference Update="FluentAssertions" />
+        <PackageReference Update="AwesomeAssertions" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" />
         <PackageReference Update="xunit" />
         <PackageReference Update="xunit.runner.visualstudio">


### PR DESCRIPTION
Switch the test suite to AwesomeAssertions and update centralized package references to the current 9.4.0 release.