### PR TITLE
`IdentityModel.AspNetCore.OAuth2Introspection` => `Duende.AspNetCore.Authentication.OAuth2Introspection`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Grpc" Version="2.46.6" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.80.0" />
     <PackageVersion Include="Grpc.Net.Common" Version="2.80.0" />
-    <PackageVersion Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
+    <PackageVersion Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="7.0.1" />
     <PackageVersion Include="jose-jwt" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />

--- a/src/Zitadel/Authentication/Options/ZitadelIntrospectionOptions.cs
+++ b/src/Zitadel/Authentication/Options/ZitadelIntrospectionOptions.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.AspNetCore.OAuth2Introspection;
+﻿using Duende.AspNetCore.Authentication.OAuth2Introspection;
 
 namespace Zitadel.Authentication.Options;
 

--- a/src/Zitadel/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Zitadel/Extensions/ApplicationBuilderExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System.Security.Claims;
 using System.Text.Json;
 
-using IdentityModel.Client;
+using Duende.AspNetCore.Authentication.OAuth2Introspection;
+using Duende.IdentityModel.Client;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth.Claims;
@@ -157,7 +158,6 @@ public static class ApplicationBuilderExtensions
                     options.ClientId = zitadelOptions.ClientId;
                     options.ClientSecret = zitadelOptions.ClientSecret;
                     options.DiscoveryPolicy = zitadelOptions.DiscoveryPolicy;
-                    options.EnableCaching = zitadelOptions.EnableCaching;
                     options.IntrospectionEndpoint = zitadelOptions.IntrospectionEndpoint;
                     options.SaveToken = zitadelOptions.SaveToken;
                     options.TokenRetriever = zitadelOptions.TokenRetriever;
@@ -222,9 +222,16 @@ public static class ApplicationBuilderExtensions
                     options.ClientId = null;
                     options.ClientSecret = null;
                     options.ClientCredentialStyle = ClientCredentialStyle.PostBody;
+                    var authority = options.Authority;
+                    if (string.IsNullOrWhiteSpace(authority))
+                    {
+                        throw new InvalidOperationException(
+                            "Authority must be configured when JwtProfile is used for introspection.");
+                    }
+
                     options.Events.OnUpdateClientAssertion += async context =>
                     {
-                        var jwt = await zitadelOptions.JwtProfile.GetSignedJwtAsync(options.Authority);
+                        var jwt = await zitadelOptions.JwtProfile.GetSignedJwtAsync(authority);
                         context.ClientAssertion = new()
                         {
                             Type = ZitadelIntrospectionOptions.JwtBearerClientAssertionType,

--- a/src/Zitadel/Zitadel.csproj
+++ b/src/Zitadel/Zitadel.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Grpc" />
         <PackageReference Include="Grpc.Net.ClientFactory" />
         <PackageReference Include="Grpc.Net.Common" />
-        <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" />
+        <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" />
         <PackageReference Include="jose-jwt" />
     </ItemGroup>
     


### PR DESCRIPTION
This MR migrates OAuth2 token introspection from the deprecated IdentityModel package to the maintained Duende package and tightens runtime safety for JWT-profile signing.

## Why this change

- `IdentityModel.AspNetCore.OAuth2Introspection` is deprecated / legacy and no longer maintained on NuGet.
- The maintainers officially rebranded it to `Duende.AspNetCore.Authentication.OAuth2Introspection` and recommend updating references.
- Duende is the actively maintained line with current docs/releases and `net10.0` support, which matches this repository’s target.

## What changed

- **Package migration**
  - `Directory.Packages.props`
    - `IdentityModel.AspNetCore.OAuth2Introspection` `6.2.0` -> `Duende.AspNetCore.Authentication.OAuth2Introspection` `7.0.1`
  - `src/Zitadel/Zitadel.csproj`
    - package reference switched to Duende

- **Namespace updates**
  - `src/Zitadel/Authentication/Options/ZitadelIntrospectionOptions.cs`
    - `using IdentityModel.AspNetCore.OAuth2Introspection` -> `using Duende.AspNetCore.Authentication.OAuth2Introspection`
  - `src/Zitadel/Extensions/ApplicationBuilderExtensions.cs`
    - `using IdentityModel.Client` -> `using Duende.IdentityModel.Client`
    - added `using Duende.AspNetCore.Authentication.OAuth2Introspection`

- **Duende API alignment + safety fix**
  - Removed `options.EnableCaching = ...` assignment (property not available in Duende 7 options).
  - Replaced unsafe authority usage in JWT profile flow:
    - before: `GetSignedJwtAsync(options.Authority!)`
    - now: fail-fast validate `Authority`, capture validated local `authority`, then call `GetSignedJwtAsync(authority)`.
  - Added explicit configuration-time exception when `JwtProfile` is set but `Authority` is missing/blank.

## Behavior impact

- Functional behavior is unchanged for valid configurations.
- Misconfigured `JwtProfile` flows now fail early with a clear error instead of relying on null-forgiving behavior.
- This migration tracks the official maintained package line.

## Official references

- Deprecated old package: [IdentityModel.AspNetCore.OAuth2Introspection on NuGet](https://www.nuget.org/packages/IdentityModel.AspNetCore.OAuth2Introspection)
- Maintainer rebrand notice: [README (raw) in DuendeArchive](https://raw.githubusercontent.com/DuendeArchive/IdentityModel.AspNetCore.OAuth2Introspection/main/README.md)
- New package: [Duende.AspNetCore.Authentication.OAuth2Introspection on NuGet](https://www.nuget.org/packages/Duende.AspNetCore.Authentication.OAuth2Introspection)
- Official docs: [Duende Introspection overview](https://docs.duendesoftware.com/introspection/)
- Options/API docs: [Duende Introspection options](https://docs.duendesoftware.com/introspection/options/)